### PR TITLE
feat: New serializer | fix: .svelte.[tj]s not transformed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Class that don't only contains `$persist` are not transformed
+- `.svelte.ts`/`.svelte.js` file not transformed ([Issue#2])
+- Unit test are not up to date with the code
+
+### Added
+
+- New serializer ([php-serialize](https://www.npmjs.com/package/php-serialize))
+- New serializer ([serialize-anything](https://www.npmjs.com/package/serialize-anything))
+- Add a new Vite plugin to handle svelte module (`.svelte.ts`/`.svelte.js` file) ([Issue#2])
+
+### Deprecated
+
+- Deprecate the default import of `@macfja/svelte-persistent-runes/preprocessor`
+
+## [1.0.0]
+
+First version
+
+[unreleased]: https://github.com/MacFJA/svelte-persistent-runes/compare/1.0.0...HEAD
+[1.0.0]: https://github.com/MacFJA/svelte-persistent-runes/releases/tag/1.0.0
+
+[Issue#2]: https://github.com/MacFJA/svelte-persistent-runes/issues/2

--- a/biome.json
+++ b/biome.json
@@ -19,7 +19,8 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"correctness": { "noUnusedImports": "error" }
 		}
 	},
 	"javascript": {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,14 @@
 			"default": "./dist/index.js"
 		},
 		"./preprocessor": {
-			"types": "./dist/plugin.d.ts",
-			"import": "./dist/plugin.mjs",
-			"default": "./dist/plugin.js"
+			"types": "./dist/preprocessor.d.ts",
+			"import": "./dist/preprocessor.mjs",
+			"default": "./dist/preprocessor.js"
+		},
+		"./plugins": {
+			"types": "./dist/plugins.d.ts",
+			"import": "./dist/plugins.mjs",
+			"default": "./dist/plugins.js"
 		},
 		"./options": {
 			"types": "./dist/options.d.ts",
@@ -48,15 +53,21 @@
 	"dependencies": {
 		"@macfja/serializer": "^1.1.4",
 		"browser-cookies": "^1.2.0",
+		"cookie": "^1.0.2",
 		"devalue": "^5.1.1",
 		"esserializer": "^1.3.11",
 		"next-json": "^0.4.0",
+		"php-serialize": "^5.0.1",
+		"serialize-anything": "^1.2.3",
 		"sjcl-codec-hex": "^1.0.0",
 		"sjcl-es": "^2.0.0",
 		"source-map": "^0.7.4",
 		"superjson": "^2.2.2",
 		"svelte": "^5.0.0",
 		"ts-morph": "^24.0.0"
+	},
+	"peerDependencies": {
+		"vite": "^5 || ^6"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
@@ -66,7 +77,8 @@
 		"prettier-package-json": "^2.8.0",
 		"rollup": "^4.28.1",
 		"tsimp": "^2.0.12",
-		"typescript": "^5.7.2"
+		"typescript": "^5.7.2",
+		"vite": "^6.2.1"
 	},
 	"keywords": [
 		"cookie",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       browser-cookies:
         specifier: ^1.2.0
         version: 1.2.0
+      cookie:
+        specifier: ^1.0.2
+        version: 1.0.2
       devalue:
         specifier: ^5.1.1
         version: 5.1.1
@@ -23,6 +26,12 @@ importers:
       next-json:
         specifier: ^0.4.0
         version: 0.4.0
+      php-serialize:
+        specifier: ^5.0.1
+        version: 5.0.1
+      serialize-anything:
+        specifier: ^1.2.3
+        version: 1.2.3
       sjcl-codec-hex:
         specifier: ^1.0.0
         version: 1.0.0
@@ -66,6 +75,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
+      vite:
+        specifier: ^6.2.1
+        version: 6.2.1
 
 packages:
 
@@ -140,8 +152,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.25.0':
+    resolution: {integrity: sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.23.1':
     resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.0':
+    resolution: {integrity: sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -152,8 +176,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.25.0':
+    resolution: {integrity: sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.23.1':
     resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.0':
+    resolution: {integrity: sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -164,8 +200,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.25.0':
+    resolution: {integrity: sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.23.1':
     resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.0':
+    resolution: {integrity: sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -176,8 +224,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.25.0':
+    resolution: {integrity: sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.23.1':
     resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.0':
+    resolution: {integrity: sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -188,8 +248,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.25.0':
+    resolution: {integrity: sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.23.1':
     resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.0':
+    resolution: {integrity: sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -200,8 +272,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.0':
+    resolution: {integrity: sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.23.1':
     resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.0':
+    resolution: {integrity: sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -212,8 +296,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.0':
+    resolution: {integrity: sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.23.1':
     resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.0':
+    resolution: {integrity: sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -224,8 +320,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.0':
+    resolution: {integrity: sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.23.1':
     resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.0':
+    resolution: {integrity: sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -236,8 +344,26 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.0':
+    resolution: {integrity: sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.0':
+    resolution: {integrity: sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.23.1':
     resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.0':
+    resolution: {integrity: sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -248,8 +374,20 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
+  '@esbuild/openbsd-arm64@0.25.0':
+    resolution: {integrity: sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.23.1':
     resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.0':
+    resolution: {integrity: sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -260,8 +398,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.25.0':
+    resolution: {integrity: sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.23.1':
     resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.25.0':
+    resolution: {integrity: sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -272,8 +422,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.0':
+    resolution: {integrity: sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.23.1':
     resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.0':
+    resolution: {integrity: sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -397,8 +559,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rollup/rollup-android-arm-eabi@4.35.0':
+    resolution: {integrity: sha512-uYQ2WfPaqz5QtVgMxfN6NpLD+no0MYHDBywl7itPYd3K5TjjSghNKmX8ic9S8NU8w81NVhJv/XojcHptRly7qQ==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.28.1':
     resolution: {integrity: sha512-EbkK285O+1YMrg57xVA+Dp0tDBRB93/BZKph9XhMjezf6F4TpYjaUSuPt5J0fZXlSag0LmZAsTmdGGqPp4pQFA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.35.0':
+    resolution: {integrity: sha512-FtKddj9XZudurLhdJnBl9fl6BwCJ3ky8riCXjEw3/UIbjmIY58ppWwPEvU3fNu+W7FUsAsB1CdH+7EQE6CXAPA==}
     cpu: [arm64]
     os: [android]
 
@@ -407,8 +579,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.35.0':
+    resolution: {integrity: sha512-Uk+GjOJR6CY844/q6r5DR/6lkPFOw0hjfOIzVx22THJXMxktXG6CbejseJFznU8vHcEBLpiXKY3/6xc+cBm65Q==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.28.1':
     resolution: {integrity: sha512-WsvbOunsUk0wccO/TV4o7IKgloJ942hVFK1CLatwv6TJspcCZb9umQkPdvB7FihmdxgaKR5JyxDjWpCOp4uZlQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.35.0':
+    resolution: {integrity: sha512-3IrHjfAS6Vkp+5bISNQnPogRAW5GAV1n+bNCrDwXmfMHbPl5EhTmWtfmwlJxFRUCBZ+tZ/OxDyU08aF6NI/N5Q==}
     cpu: [x64]
     os: [darwin]
 
@@ -417,8 +599,18 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@rollup/rollup-freebsd-arm64@4.35.0':
+    resolution: {integrity: sha512-sxjoD/6F9cDLSELuLNnY0fOrM9WA0KrM0vWm57XhrIMf5FGiN8D0l7fn+bpUeBSU7dCgPV2oX4zHAsAXyHFGcQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@rollup/rollup-freebsd-x64@4.28.1':
     resolution: {integrity: sha512-m/uYasxkUevcFTeRSM9TeLyPe2QDuqtjkeoTpP9SW0XxUWfcYrGDMkO/m2tTw+4NMAF9P2fU3Mw4ahNvo7QmsQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.35.0':
+    resolution: {integrity: sha512-2mpHCeRuD1u/2kruUiHSsnjWtHjqVbzhBkNVQ1aVD63CcexKVcQGwJ2g5VphOd84GvxfSvnnlEyBtQCE5hxVVw==}
     cpu: [x64]
     os: [freebsd]
 
@@ -427,8 +619,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.35.0':
+    resolution: {integrity: sha512-mrA0v3QMy6ZSvEuLs0dMxcO2LnaCONs1Z73GUDBHWbY8tFFocM6yl7YyMu7rz4zS81NDSqhrUuolyZXGi8TEqg==}
+    cpu: [arm]
+    os: [linux]
+
   '@rollup/rollup-linux-arm-musleabihf@4.28.1':
     resolution: {integrity: sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.35.0':
+    resolution: {integrity: sha512-DnYhhzcvTAKNexIql8pFajr0PiDGrIsBYPRvCKlA5ixSS3uwo/CWNZxB09jhIapEIg945KOzcYEAGGSmTSpk7A==}
     cpu: [arm]
     os: [linux]
 
@@ -437,8 +639,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-gnu@4.35.0':
+    resolution: {integrity: sha512-uagpnH2M2g2b5iLsCTZ35CL1FgyuzzJQ8L9VtlJ+FckBXroTwNOaD0z0/UF+k5K3aNQjbm8LIVpxykUOQt1m/A==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-musl@4.28.1':
     resolution: {integrity: sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.35.0':
+    resolution: {integrity: sha512-XQxVOCd6VJeHQA/7YcqyV0/88N6ysSVzRjJ9I9UA/xXpEsjvAgDTgH3wQYz5bmr7SPtVK2TsP2fQ2N9L4ukoUg==}
     cpu: [arm64]
     os: [linux]
 
@@ -447,8 +659,18 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@rollup/rollup-linux-loongarch64-gnu@4.35.0':
+    resolution: {integrity: sha512-5pMT5PzfgwcXEwOaSrqVsz/LvjDZt+vQ8RT/70yhPU06PTuq8WaHhfT1LW+cdD7mW6i/J5/XIkX/1tCAkh1W6g==}
+    cpu: [loong64]
+    os: [linux]
+
   '@rollup/rollup-linux-powerpc64le-gnu@4.28.1':
     resolution: {integrity: sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.35.0':
+    resolution: {integrity: sha512-c+zkcvbhbXF98f4CtEIP1EBA/lCic5xB0lToneZYvMeKu5Kamq3O8gqrxiYYLzlZH6E3Aq+TSW86E4ay8iD8EA==}
     cpu: [ppc64]
     os: [linux]
 
@@ -457,8 +679,18 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@rollup/rollup-linux-riscv64-gnu@4.35.0':
+    resolution: {integrity: sha512-s91fuAHdOwH/Tad2tzTtPX7UZyytHIRR6V4+2IGlV0Cej5rkG0R61SX4l4y9sh0JBibMiploZx3oHKPnQBKe4g==}
+    cpu: [riscv64]
+    os: [linux]
+
   '@rollup/rollup-linux-s390x-gnu@4.28.1':
     resolution: {integrity: sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.35.0':
+    resolution: {integrity: sha512-hQRkPQPLYJZYGP+Hj4fR9dDBMIM7zrzJDWFEMPdTnTy95Ljnv0/4w/ixFw3pTBMEuuEuoqtBINYND4M7ujcuQw==}
     cpu: [s390x]
     os: [linux]
 
@@ -467,8 +699,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-gnu@4.35.0':
+    resolution: {integrity: sha512-Pim1T8rXOri+0HmV4CdKSGrqcBWX0d1HoPnQ0uw0bdp1aP5SdQVNBy8LjYncvnLgu3fnnCt17xjWGd4cqh8/hA==}
+    cpu: [x64]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-musl@4.28.1':
     resolution: {integrity: sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.35.0':
+    resolution: {integrity: sha512-QysqXzYiDvQWfUiTm8XmJNO2zm9yC9P/2Gkrwg2dH9cxotQzunBHYr6jk4SujCTqnfGxduOmQcI7c2ryuW8XVg==}
     cpu: [x64]
     os: [linux]
 
@@ -477,13 +719,28 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rollup/rollup-win32-arm64-msvc@4.35.0':
+    resolution: {integrity: sha512-OUOlGqPkVJCdJETKOCEf1mw848ZyJ5w50/rZ/3IBQVdLfR5jk/6Sr5m3iO2tdPgwo0x7VcncYuOvMhBWZq8ayg==}
+    cpu: [arm64]
+    os: [win32]
+
   '@rollup/rollup-win32-ia32-msvc@4.28.1':
     resolution: {integrity: sha512-ZkyTJ/9vkgrE/Rk9vhMXhf8l9D+eAhbAVbsGsXKy2ohmJaWg0LPQLnIxRdRp/bKyr8tXuPlXhIoGlEB5XpJnGA==}
     cpu: [ia32]
     os: [win32]
 
+  '@rollup/rollup-win32-ia32-msvc@4.35.0':
+    resolution: {integrity: sha512-2/lsgejMrtwQe44glq7AFFHLfJBPafpsTa6JvP2NGef/ifOa4KBoglVf7AKN7EV9o32evBPRqfg96fEHzWo5kw==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-msvc@4.28.1':
     resolution: {integrity: sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.35.0':
+    resolution: {integrity: sha512-PIQeY5XDkrOysbQblSW7v3l1MDZzkTEzAfTPkj5VAu3FW8fS4ynyLg2sINp0fp3SjZ8xkRYpLqoKcYqAkhU1dw==}
     cpu: [x64]
     os: [win32]
 
@@ -737,6 +994,10 @@ packages:
     resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
+
   copy-anything@3.0.5:
     resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
     engines: {node: '>=12.13'}
@@ -781,6 +1042,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  deep-copy-all@1.3.4:
+    resolution: {integrity: sha512-5hHGjeggREJDKWBvxVv5RPKtcgKpraHAPu4DcvUcP8usgmK93UzL9oOPsV3h6VCrD2+wmgq0kHha2rnXZHAV3A==}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -853,6 +1117,11 @@ packages:
 
   esbuild@0.23.1:
     resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.25.0:
+    resolution: {integrity: sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1349,6 +1618,11 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  nanoid@3.3.9:
+    resolution: {integrity: sha512-SppoicMGpZvbF1l3z4x7No3OlIjP7QJvC9XR7AhZr1kL133KHnKPztkKDc+Ir4aJ/1VhTySrtKhrsycmrMQfvg==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   next-json@0.4.0:
     resolution: {integrity: sha512-AwnKfYVazg1D9eHkyzeyHFIrtrIwjL2Rwnj49EBzVvjHA/d7RgsQ0FGnLbnIM26NfJ79SfQg4n7iQNKEtXNbAg==}
     engines: {node: '>=14.0'}
@@ -1478,6 +1752,10 @@ packages:
     resolution: {integrity: sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==}
     engines: {node: '>=12'}
 
+  php-serialize@5.0.1:
+    resolution: {integrity: sha512-+uxULDruX7uwGZmC1HjcvQMg6APyK1wzWXnaRR0Vxb7Vk4YMn5/Chp9tm+ccNqmXOtfZ/oZVbR8GZnPnojltDw==}
+    engines: {node: '>= 8'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1519,6 +1797,10 @@ packages:
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
+
+  postcss@8.5.3:
+    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prettier-package-json@2.8.0:
     resolution: {integrity: sha512-WxtodH/wWavfw3MR7yK/GrS4pASEQ+iSTkdtSxPJWvqzG55ir5nvbLt9rw5AOiEcqqPCRM92WCtR1rk3TG3JSQ==}
@@ -1590,6 +1872,11 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rollup@4.35.0:
+    resolution: {integrity: sha512-kg6oI4g+vc41vePJyO6dHt/yl0Rz3Thv0kJeVQ3D1kS3E5XSuKbPc29G4IpT/Kv1KQwgHVcN+HtyS+HYLNSvQg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1616,6 +1903,9 @@ packages:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
     hasBin: true
+
+  serialize-anything@1.2.3:
+    resolution: {integrity: sha512-Jp5zqFoQu8DpL9s/XR0aaf/RC0Z07DZInkbwLkR9+oAOIajOQlZ/pJFc4eVpfY3ObunW7cX361sIZVZMbbPG/g==}
 
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
@@ -1693,6 +1983,10 @@ packages:
 
   sort-order@1.1.2:
     resolution: {integrity: sha512-Q8tOrwB1TSv9fNUXym9st3TZJODtmcOIi2JWCkVNQPrRg17KPwlpwweTEb7pMwUIFMTAgx2/JsQQXEPFzYQj3A==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   source-map@0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
@@ -1854,6 +2148,46 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
+  vite@6.2.1:
+    resolution: {integrity: sha512-n2GnqDb6XPhlt9B8olZPrgMD/es/Nd1RdChF6CBD/fHW6pUyUTt2sQW2fPRX5GiD9XEa6+8A6A4f2vT6pSsE7Q==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
@@ -1986,73 +2320,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.23.1':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.0':
+    optional: true
+
   '@esbuild/android-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.0':
     optional: true
 
   '@esbuild/android-arm@0.23.1':
     optional: true
 
+  '@esbuild/android-arm@0.25.0':
+    optional: true
+
   '@esbuild/android-x64@0.23.1':
+    optional: true
+
+  '@esbuild/android-x64@0.25.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.23.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.23.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.23.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.0':
     optional: true
 
   '@esbuild/linux-arm64@0.23.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.0':
+    optional: true
+
   '@esbuild/linux-arm@0.23.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.0':
     optional: true
 
   '@esbuild/linux-ia32@0.23.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.23.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.23.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.23.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.0':
     optional: true
 
   '@esbuild/linux-x64@0.23.1':
     optional: true
 
+  '@esbuild/linux-x64@0.25.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.0':
+    optional: true
+
   '@esbuild/netbsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.0':
     optional: true
 
   '@esbuild/openbsd-arm64@0.23.1':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.25.0':
+    optional: true
+
   '@esbuild/openbsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.0':
     optional: true
 
   '@esbuild/sunos-x64@0.23.1':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.0':
     optional: true
 
   '@esbuild/win32-ia32@0.23.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.0':
+    optional: true
+
   '@esbuild/win32-x64@0.23.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.0':
     optional: true
 
   '@isaacs/cached@1.0.1':
@@ -2176,58 +2585,115 @@ snapshots:
   '@rollup/rollup-android-arm-eabi@4.28.1':
     optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.35.0':
+    optional: true
+
   '@rollup/rollup-android-arm64@4.28.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.35.0':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.28.1':
     optional: true
 
+  '@rollup/rollup-darwin-arm64@4.35.0':
+    optional: true
+
   '@rollup/rollup-darwin-x64@4.28.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.35.0':
     optional: true
 
   '@rollup/rollup-freebsd-arm64@4.28.1':
     optional: true
 
+  '@rollup/rollup-freebsd-arm64@4.35.0':
+    optional: true
+
   '@rollup/rollup-freebsd-x64@4.28.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.35.0':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.28.1':
     optional: true
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.35.0':
+    optional: true
+
   '@rollup/rollup-linux-arm-musleabihf@4.28.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.35.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.28.1':
     optional: true
 
+  '@rollup/rollup-linux-arm64-gnu@4.35.0':
+    optional: true
+
   '@rollup/rollup-linux-arm64-musl@4.28.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.35.0':
     optional: true
 
   '@rollup/rollup-linux-loongarch64-gnu@4.28.1':
     optional: true
 
+  '@rollup/rollup-linux-loongarch64-gnu@4.35.0':
+    optional: true
+
   '@rollup/rollup-linux-powerpc64le-gnu@4.28.1':
+    optional: true
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.35.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.28.1':
     optional: true
 
+  '@rollup/rollup-linux-riscv64-gnu@4.35.0':
+    optional: true
+
   '@rollup/rollup-linux-s390x-gnu@4.28.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.35.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.28.1':
     optional: true
 
+  '@rollup/rollup-linux-x64-gnu@4.35.0':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.28.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.35.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.28.1':
     optional: true
 
+  '@rollup/rollup-win32-arm64-msvc@4.35.0':
+    optional: true
+
   '@rollup/rollup-win32-ia32-msvc@4.28.1':
     optional: true
 
+  '@rollup/rollup-win32-ia32-msvc@4.35.0':
+    optional: true
+
   '@rollup/rollup-win32-x64-msvc@4.28.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.35.0':
     optional: true
 
   '@sindresorhus/merge-streams@2.3.0': {}
@@ -2506,6 +2972,8 @@ snapshots:
 
   convert-to-spaces@2.0.1: {}
 
+  cookie@1.0.2: {}
+
   copy-anything@3.0.5:
     dependencies:
       is-what: 4.1.16
@@ -2561,6 +3029,8 @@ snapshots:
   debug@4.4.0:
     dependencies:
       ms: 2.1.3
+
+  deep-copy-all@1.3.4: {}
 
   deepmerge@4.3.1: {}
 
@@ -2697,6 +3167,34 @@ snapshots:
       '@esbuild/win32-arm64': 0.23.1
       '@esbuild/win32-ia32': 0.23.1
       '@esbuild/win32-x64': 0.23.1
+
+  esbuild@0.25.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.0
+      '@esbuild/android-arm': 0.25.0
+      '@esbuild/android-arm64': 0.25.0
+      '@esbuild/android-x64': 0.25.0
+      '@esbuild/darwin-arm64': 0.25.0
+      '@esbuild/darwin-x64': 0.25.0
+      '@esbuild/freebsd-arm64': 0.25.0
+      '@esbuild/freebsd-x64': 0.25.0
+      '@esbuild/linux-arm': 0.25.0
+      '@esbuild/linux-arm64': 0.25.0
+      '@esbuild/linux-ia32': 0.25.0
+      '@esbuild/linux-loong64': 0.25.0
+      '@esbuild/linux-mips64el': 0.25.0
+      '@esbuild/linux-ppc64': 0.25.0
+      '@esbuild/linux-riscv64': 0.25.0
+      '@esbuild/linux-s390x': 0.25.0
+      '@esbuild/linux-x64': 0.25.0
+      '@esbuild/netbsd-arm64': 0.25.0
+      '@esbuild/netbsd-x64': 0.25.0
+      '@esbuild/openbsd-arm64': 0.25.0
+      '@esbuild/openbsd-x64': 0.25.0
+      '@esbuild/sunos-x64': 0.25.0
+      '@esbuild/win32-arm64': 0.25.0
+      '@esbuild/win32-ia32': 0.25.0
+      '@esbuild/win32-x64': 0.25.0
 
   escalade@3.2.0: {}
 
@@ -3163,6 +3661,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  nanoid@3.3.9: {}
+
   next-json@0.4.0: {}
 
   nice-try@1.0.5: {}
@@ -3281,6 +3781,8 @@ snapshots:
 
   path-type@5.0.0: {}
 
+  php-serialize@5.0.1: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -3313,6 +3815,12 @@ snapshots:
       irregular-plurals: 3.5.0
 
   possible-typed-array-names@1.0.0: {}
+
+  postcss@8.5.3:
+    dependencies:
+      nanoid: 3.3.9
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prettier-package-json@2.8.0:
     dependencies:
@@ -3418,6 +3926,31 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.28.1
       fsevents: 2.3.3
 
+  rollup@4.35.0:
+    dependencies:
+      '@types/estree': 1.0.6
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.35.0
+      '@rollup/rollup-android-arm64': 4.35.0
+      '@rollup/rollup-darwin-arm64': 4.35.0
+      '@rollup/rollup-darwin-x64': 4.35.0
+      '@rollup/rollup-freebsd-arm64': 4.35.0
+      '@rollup/rollup-freebsd-x64': 4.35.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.35.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.35.0
+      '@rollup/rollup-linux-arm64-gnu': 4.35.0
+      '@rollup/rollup-linux-arm64-musl': 4.35.0
+      '@rollup/rollup-linux-loongarch64-gnu': 4.35.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.35.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.35.0
+      '@rollup/rollup-linux-s390x-gnu': 4.35.0
+      '@rollup/rollup-linux-x64-gnu': 4.35.0
+      '@rollup/rollup-linux-x64-musl': 4.35.0
+      '@rollup/rollup-win32-arm64-msvc': 4.35.0
+      '@rollup/rollup-win32-ia32-msvc': 4.35.0
+      '@rollup/rollup-win32-x64-msvc': 4.35.0
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -3442,6 +3975,10 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.6.3: {}
+
+  serialize-anything@1.2.3:
+    dependencies:
+      deep-copy-all: 1.3.4
 
   serialize-error@7.0.1:
     dependencies:
@@ -3516,6 +4053,8 @@ snapshots:
   sort-object-keys@1.1.3: {}
 
   sort-order@1.1.2: {}
+
+  source-map-js@1.2.1: {}
 
   source-map@0.7.4: {}
 
@@ -3726,6 +4265,14 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  vite@6.2.1:
+    dependencies:
+      esbuild: 0.25.0
+      postcss: 8.5.3
+      rollup: 4.35.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   walk-up-path@4.0.0: {}
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,12 +1,8 @@
-import * as macfja from "@macfja/serializer";
 import {
 	type CookieOptions,
 	get as getCookie,
 	set as setCookie,
 } from "browser-cookies";
-import * as dv from "devalue";
-import ESSerializer from "esserializer";
-import { NJSON } from "next-json";
 // @ts-ignore
 import toHex from "sjcl-codec-hex/from-bits";
 // @ts-ignore
@@ -15,6 +11,15 @@ import fromHex from "sjcl-codec-hex/to-bits";
 import sjcl from "sjcl-es";
 import * as superjson from "superjson";
 import type { PersistentRunesOptions } from "./index";
+import {
+	DevalueSerializerFactory,
+	ESSerializerSerializerFactory,
+	JsonSerializerFactory,
+	MacfjaSerializerFactory,
+	NextJsonSerializerFactory,
+	PhpSerializeSerializerFactory,
+	SerializeAnythingSerializerFactory,
+} from "./serializer-factory";
 
 export type PersistentRunesStorage = Pick<
 	PersistentRunesOptions,
@@ -25,78 +30,6 @@ export type PersistentRunesSerializer = Pick<
 	"serialize" | "deserialize"
 >;
 
-export function JsonSerializerFactory(options?: {
-	replacer?: Parameters<typeof JSON.stringify>[1];
-	reviver?: Parameters<typeof JSON.parse>[1];
-	space?: Parameters<typeof JSON.stringify>[2];
-}): PersistentRunesSerializer {
-	return {
-		serialize<T>(input: T): string {
-			return JSON.stringify(input, options?.replacer, options?.space);
-		},
-		deserialize<T>(input: string): T {
-			return JSON.parse(input, options?.reviver) as T;
-		},
-	};
-}
-
-export function DevalueSerializerFactory(options?: {
-	reducers?: Parameters<typeof dv.stringify>[1];
-	revivers?: Parameters<typeof dv.parse>[1];
-}): PersistentRunesSerializer {
-	return {
-		serialize<T>(data: T): string {
-			return dv.stringify(data, options?.reducers);
-		},
-		deserialize<T>(input: string): T {
-			return dv.parse(input, options?.revivers);
-		},
-	};
-}
-
-export function ESSerializerSerializerFactory(options?: {
-	serializeOption?: Parameters<typeof ESSerializer.serialize>[1];
-	classes?: Parameters<typeof ESSerializer.deserialize>[1];
-}): PersistentRunesSerializer {
-	return {
-		serialize<T>(data: T): string {
-			return ESSerializer.serialize(data, options?.serializeOption);
-		},
-		deserialize<T>(input: string): T {
-			return ESSerializer.deserialize(input, options?.classes);
-		},
-	};
-}
-export function MacfjaSerializerFactory(options?: {
-	allowedClasses?: Parameters<typeof macfja.deserialize>[1];
-}): PersistentRunesSerializer {
-	return {
-		serialize<T>(data: T): string {
-			return macfja.serialize(data);
-		},
-		deserialize<T>(input: string): T {
-			return macfja.deserialize(input, options?.allowedClasses);
-		},
-	};
-}
-export function NextJsonSerializerFactory(options?: {
-	stringifyOptionsOrReplacer?: Parameters<typeof NJSON.stringify>[1];
-	space?: Parameters<typeof NJSON.stringify>[2];
-	parseOptionsOrReviver?: Parameters<typeof NJSON.parse>[1];
-}): PersistentRunesSerializer {
-	return {
-		serialize<T>(data: T): string {
-			return NJSON.stringify(
-				data,
-				options?.stringifyOptionsOrReplacer,
-				options?.space,
-			);
-		},
-		deserialize<T>(input: string): T {
-			return NJSON.parse(input, options?.parseOptionsOrReviver);
-		},
-	};
-}
 export const SuperJsonSerializer: PersistentRunesSerializer = {
 	serialize<T>(input: T): string {
 		return superjson.stringify(input);
@@ -185,6 +118,10 @@ export const MacfjaSerializer: PersistentRunesSerializer =
 	MacfjaSerializerFactory();
 export const NextJsonSerializer: PersistentRunesSerializer =
 	NextJsonSerializerFactory();
+export const PhpSerializeSerializer: PersistentRunesSerializer =
+	PhpSerializeSerializerFactory();
+export const SerializeAnythingSerializer: PersistentRunesSerializer =
+	SerializeAnythingSerializerFactory();
 
 /**
  * Create a `PersistentRunesOptions` from a serializer and a storage
@@ -200,3 +137,5 @@ export function buildOptions(
 		...(storage ?? BrowserLocalStorage),
 	};
 }
+
+export * from "./serializer-factory";

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -1,11 +1,11 @@
 import def, { type ExecutionContext, type TestFn } from "ava";
-import plugin from "./plugin";
+import { persistPreprocessor } from "./plugins";
 
 const test: TestFn = def as unknown as TestFn;
 
 test("Transform variable", async (t: ExecutionContext) => {
 	const input = "let name = $persist('John', 'name');";
-	const actual = await plugin().script?.({
+	const actual = await persistPreprocessor().script?.({
 		content: input,
 		filename: "test.js",
 		attributes: {},
@@ -17,7 +17,7 @@ test("Transform variable", async (t: ExecutionContext) => {
 		`import * as dyn___persistent_runes from "@macfja/svelte-persistent-runes";
 
 let name = $state(dyn___persistent_runes.load('name', undefined) ?? 'John');
-$effect.root(() => {$effect(() => dyn___persistent_runes.save('name', name, undefined))});`,
+$effect.root(() => {$effect(() => dyn___persistent_runes.save('name', $state.snapshot(name), undefined))});`,
 	);
 	t.is(
 		actual?.map,
@@ -27,7 +27,7 @@ $effect.root(() => {$effect(() => dyn___persistent_runes.save('name', name, unde
 test("Transform variable with options", async (t: ExecutionContext) => {
 	const input =
 		"let name = $persist('John', 'name', {serialize: (v) => JSON.stringify(v)});";
-	const actual = await plugin().script?.({
+	const actual = await persistPreprocessor().script?.({
 		content: input,
 		filename: "test.js",
 		attributes: {},
@@ -38,7 +38,7 @@ test("Transform variable with options", async (t: ExecutionContext) => {
 		`import * as dyn___persistent_runes from "@macfja/svelte-persistent-runes";
 
 let name = $state(dyn___persistent_runes.load('name', { serialize: (v) => JSON.stringify(v) }) ?? 'John');
-$effect.root(() => {$effect(() => dyn___persistent_runes.save('name', name, { serialize: (v) => JSON.stringify(v) }))});`,
+$effect.root(() => {$effect(() => dyn___persistent_runes.save('name', $state.snapshot(name), { serialize: (v) => JSON.stringify(v) }))});`,
 	);
 
 	t.is(
@@ -49,7 +49,7 @@ $effect.root(() => {$effect(() => dyn___persistent_runes.save('name', name, { se
 
 test("Transform class", async (t: ExecutionContext) => {
 	const input = "class Test { name = $persist('John', 'name'); }";
-	const actual = await plugin().script?.({
+	const actual = await persistPreprocessor().script?.({
 		content: input,
 		filename: "test.js",
 		attributes: {},
@@ -62,7 +62,7 @@ test("Transform class", async (t: ExecutionContext) => {
 class Test { name = $state(dyn___persistent_runes.load('name', undefined) ?? 'John');
 
     constructor() {
-        $effect.root(() => {$effect(() => dyn___persistent_runes.save('name', this.name, undefined))});
+        $effect.root(() => {$effect(() => dyn___persistent_runes.save('name', $state.snapshot(this.name), undefined))});
     }
  }`,
 	);
@@ -77,7 +77,7 @@ test("Transform class with several props", async (t: ExecutionContext) => {
   name = $persist('John', 'name');
   age = $persist(0, 'user-age');
 }`;
-	const actual = await plugin().script?.({
+	const actual = await persistPreprocessor().script?.({
 		content: input,
 		filename: "test.js",
 		attributes: {},
@@ -92,15 +92,15 @@ class Test {
   age = $state(dyn___persistent_runes.load('user-age', undefined) ?? 0);
 
     constructor() {
-        $effect.root(() => {$effect(() => dyn___persistent_runes.save('name', this.name, undefined))
-        $effect(() => dyn___persistent_runes.save('user-age', this.age, undefined))});
+        $effect.root(() => {$effect(() => dyn___persistent_runes.save('name', $state.snapshot(this.name), undefined))
+        $effect(() => dyn___persistent_runes.save('user-age', $state.snapshot(this.age), undefined))});
     }
 }`,
 	);
 });
 test("Transform class with parent", async (t: ExecutionContext) => {
 	const input = "class Test extends Base { name = $persist('John', 'name'); }";
-	const actual = await plugin().script?.({
+	const actual = await persistPreprocessor().script?.({
 		content: input,
 		filename: "test.js",
 		attributes: {},
@@ -114,7 +114,7 @@ class Test extends Base { name = $state(dyn___persistent_runes.load('name', unde
 
     constructor(...args: any[]) {
         super(...args);
-        $effect.root(() => {$effect(() => dyn___persistent_runes.save('name', this.name, undefined))});
+        $effect.root(() => {$effect(() => dyn___persistent_runes.save('name', $state.snapshot(this.name), undefined))});
     }
  }`,
 	);
@@ -122,7 +122,7 @@ class Test extends Base { name = $state(dyn___persistent_runes.load('name', unde
 test("Transform class with constructor", async (t: ExecutionContext) => {
 	const input =
 		"class Test { name = $persist('John', 'name'); constructor() { console.log('test'); } }";
-	const actual = await plugin().script?.({
+	const actual = await persistPreprocessor().script?.({
 		content: input,
 		filename: "test.js",
 		attributes: {},
@@ -133,6 +133,6 @@ test("Transform class with constructor", async (t: ExecutionContext) => {
 		`import * as dyn___persistent_runes from "@macfja/svelte-persistent-runes";
 
 class Test { name = $state(dyn___persistent_runes.load('name', undefined) ?? 'John'); constructor() { console.log('test');
-    $effect.root(() => {$effect(() => dyn___persistent_runes.save('name', this.name, undefined))}); } }`,
+    $effect.root(() => {$effect(() => dyn___persistent_runes.save('name', $state.snapshot(this.name), undefined))}); } }`,
 	);
 });

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -1,0 +1,8 @@
+import { persistPreprocessor } from "./plugins";
+
+export default function () {
+	console.warn(
+		"[WARN] The import of default of `@macfja/svelte-persistent-runes/preprocessor` is deprecated,\n       use `persistPreprocessor` of import `@macfja/svelte-persistent-runes/plugins`",
+	);
+	return persistPreprocessor();
+}

--- a/src/serialize-anything.d.ts
+++ b/src/serialize-anything.d.ts
@@ -1,0 +1,12 @@
+module "serialize-anything" {
+	function serialize(
+		// biome-ignore lint/suspicious/noExplicitAny: Original type
+		source: any,
+		options?: {
+			maxDepth?: number;
+			pretty?: boolean;
+		},
+	);
+	// biome-ignore lint/suspicious/noExplicitAny: Original type
+	function deserialize(source: string): any;
+}

--- a/src/serializer-factory.ts
+++ b/src/serializer-factory.ts
@@ -1,0 +1,116 @@
+import * as macfja from "@macfja/serializer";
+import * as dv from "devalue";
+import ESSerializer from "esserializer";
+import { NJSON } from "next-json";
+import * as PhpSerialize from "php-serialize";
+import SerAny from "serialize-anything";
+import type { PersistentRunesSerializer } from "./options";
+
+export function PhpSerializeSerializerFactory(options?: {
+	givenOptions?: Parameters<typeof PhpSerialize.serialize>[2];
+	scope?: Parameters<typeof PhpSerialize.serialize>[1];
+}): PersistentRunesSerializer {
+	return {
+		deserialize<T>(input: string): T {
+			return PhpSerialize.unserialize(
+				input,
+				options?.scope,
+				options?.givenOptions,
+			);
+		},
+		serialize<T>(input: T): string {
+			return PhpSerialize.serialize(
+				input,
+				options?.scope,
+				options?.givenOptions,
+			);
+		},
+	};
+}
+
+export function SerializeAnythingSerializerFactory(options?: {
+	maxDepth?: number;
+	pretty?: boolean;
+}): PersistentRunesSerializer {
+	return {
+		deserialize<T>(input: string): T {
+			return SerAny.deserialize(input);
+		},
+		serialize<T>(input: T): string {
+			return SerAny.serialize(input, options);
+		},
+	};
+}
+
+export function JsonSerializerFactory(options?: {
+	replacer?: Parameters<typeof JSON.stringify>[1];
+	reviver?: Parameters<typeof JSON.parse>[1];
+	space?: Parameters<typeof JSON.stringify>[2];
+}): PersistentRunesSerializer {
+	return {
+		serialize<T>(input: T): string {
+			return JSON.stringify(input, options?.replacer, options?.space);
+		},
+		deserialize<T>(input: string): T {
+			return JSON.parse(input, options?.reviver) as T;
+		},
+	};
+}
+
+export function DevalueSerializerFactory(options?: {
+	reducers?: Parameters<typeof dv.stringify>[1];
+	revivers?: Parameters<typeof dv.parse>[1];
+}): PersistentRunesSerializer {
+	return {
+		serialize<T>(data: T): string {
+			return dv.stringify(data, options?.reducers);
+		},
+		deserialize<T>(input: string): T {
+			return dv.parse(input, options?.revivers);
+		},
+	};
+}
+
+export function ESSerializerSerializerFactory(options?: {
+	serializeOption?: Parameters<typeof ESSerializer.serialize>[1];
+	classes?: Parameters<typeof ESSerializer.deserialize>[1];
+}): PersistentRunesSerializer {
+	return {
+		serialize<T>(data: T): string {
+			return ESSerializer.serialize(data, options?.serializeOption);
+		},
+		deserialize<T>(input: string): T {
+			return ESSerializer.deserialize(input, options?.classes);
+		},
+	};
+}
+export function MacfjaSerializerFactory(options?: {
+	allowedClasses?: Parameters<typeof macfja.deserialize>[1];
+}): PersistentRunesSerializer {
+	return {
+		serialize<T>(data: T): string {
+			return macfja.serialize(data);
+		},
+		deserialize<T>(input: string): T {
+			return macfja.deserialize(input, options?.allowedClasses);
+		},
+	};
+}
+export function NextJsonSerializerFactory(options?: {
+	stringifyOptionsOrReplacer?: Parameters<typeof NJSON.stringify>[1];
+	space?: Parameters<typeof NJSON.stringify>[2];
+	parseOptionsOrReviver?: Parameters<typeof NJSON.parse>[1];
+}): PersistentRunesSerializer {
+	return {
+		serialize<T>(data: T): string {
+			return NJSON.stringify(
+				data,
+				options?.stringifyOptionsOrReplacer,
+				options?.space,
+			);
+		},
+		deserialize<T>(input: string): T {
+			return NJSON.parse(input, options?.parseOptionsOrReviver);
+		},
+	};
+}


### PR DESCRIPTION
### Fixed

- Class that don't only contains `$persist` are not transformed
- `.svelte.ts`/`.svelte.js` file not transformed (#2)
- Unit test are not up-to-date with the code

### Added

- New serializer ([php-serialize](https://www.npmjs.com/package/php-serialize))
- New serializer ([serialize-anything](https://www.npmjs.com/package/serialize-anything))
- Add a new Vite plugin to handle svelte module (`.svelte.ts`/`.svelte.js` file) (#2)

### Deprecated

- Deprecate the default import of `@macfja/svelte-persistent-runes/preprocessor`